### PR TITLE
Exercise 0 Updates

### DIFF
--- a/Exercise_0_Introduction.ipynb
+++ b/Exercise_0_Introduction.ipynb
@@ -38,7 +38,10 @@
     "    <li> Format and submit a query to the server </li>\n",
     "    <li> Process response data from the FHIR server as a JSON document.</li>\n",
     "    <li> View the resulting JSON to confirm that we successfully pulled data from the remote server.</li>\n",
-    "    </ol>\n"
+    "    </ol>\n",
+    "\n",
+    "### Icons in this Guide\n",
+    " 📘 A link to a useful external reference related to the section the icon appears in  "
    ]
   },
   {
@@ -61,38 +64,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea126dc7",
-   "metadata": {},
-   "source": [
-    "Generally speaking the pattern for a RESTful GET query appended to a URL will take the form of: \n",
-    "\n",
-    "```\n",
-    "VERB [url]/[Resource]/[id] {?parameter=[value]}\n",
-    "```\n",
-    "\n",
-    "See http://hl7.org/fhir/R4/http.html for more details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "dae0761c",
    "metadata": {},
    "source": [
     "Let's string together a basic query to get the status of our FHIR server. \n",
     "\n",
-    "Generally we'll want to use the following python notation:\n",
+    "Generally we'll want to use the following python notation for all our HTTP requests:\n",
     "\n",
     "```\n",
-    "r = requests.get(url)\n",
+    "r = s.get(url)\n",
     "```\n",
     "\n",
-    "In this case, we want to modify the general pattern with:\n",
-    "\n",
-    "- `[url] = https://api.logicahealth.org/researchonfhir/open/`\n",
-    "- `[Resource] = metadata`\n",
-    "- `[id] = status_code`\n",
-    "    \n",
-    "To view the resulting query you can just output the variable directly."
+    "In this case, we'll start with a basic query to make sure the server is up and everything is working. We'll talk more about what this request is for in the next exercise."
    ]
   },
   {
@@ -102,8 +85,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's import the requests library we'll be using for this exercise:\n",
-    "import requests"
+    "# For making HTTP requests to the FHIR server\n",
+    "import requests\n",
+    "# Python standard library API for dealing with json\n",
+    "import json\n",
+    "\n",
+    "# Configure requests session with standard headers\n",
+    "s = requests.Session()\n",
+    "s.headers.update({'Accept':'application/fhir+json', 'Content-Type': 'application/fhir+json'})\n",
+    "\n",
+    "# Optional: Turn off SSL verification. Useful when dealing with a corporate proxy with self-signed certificates.\n",
+    "s.verify = False\n",
+    "requests.packages.urllib3.disable_warnings()"
    ]
   },
   {
@@ -124,7 +117,7 @@
     }
    ],
    "source": [
-    "r = requests.get(\"https://api.logicahealth.org/researchonfhir/open/metadata/status_code\")\n",
+    "r = s.get(\"https://api.logicahealth.org/researchonfhir/open/metadata\")\n",
     "r"
    ]
   },
@@ -149,19 +142,21 @@
    "id": "79b4f77e",
    "metadata": {},
    "source": [
-    "We are now positioned to submit specific queries to our FHIR server and retrieve data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "587127ae",
-   "metadata": {},
-   "source": [
+    "We are now positioned to submit specific queries to our FHIR server and retrieve data.\n",
+    "\n",
+    "Generally speaking the pattern for a RESTful GET query appended to a URL will take the form of: \n",
+    "\n",
+    "```\n",
+    "VERB [url]/[Resource]/[id] {?parameter=[value]}\n",
+    "```\n",
+    "\n",
     "Let's submit a sample query to return the basic information from a single patient: `smart-1032702`:\n",
     "\n",
     "- `[URL] = https://api.logicahealth.org/researchonfhir/open/`\n",
     "- `[Resource] = Patient`\n",
-    "- `ID = smart-1032702`"
+    "- `ID = smart-1032702`\n",
+    "\n",
+    "📘[Read more about FHIR HTTP Interactions](http://hl7.org/fhir/R4/http.html)"
    ]
   },
   {
@@ -170,14 +165,6 @@
    "id": "38a18304",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/anaconda3/lib/python3.7/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings\n",
-      "  InsecureRequestWarning,\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -190,8 +177,8 @@
     }
    ],
    "source": [
-    "t = requests.get(f\"https://api.logicahealth.org/researchonfhir/open/Patient/smart-1032702\", headers={'Accept':'application/fhir+json'}, verify=False)\n",
-    "t"
+    "patient = s.get(f\"https://api.logicahealth.org/researchonfhir/open/Patient/smart-1032702\", headers={'Accept':'application/fhir+json'}, verify=False)\n",
+    "patient"
    ]
   },
   {
@@ -215,36 +202,17 @@
    "id": "f22de8a9",
    "metadata": {},
    "source": [
-    "We'll leverage the JSON library to convert our previously queried data into a JSON formatted file we can then output directly into our workbook to review. "
+    "The Requests library provides a `.json` method for decoding JSON HTTP response payloads into python."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7a8b2e46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's import the JSON library we'll be using\n",
-    "import json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ae62a41d",
-   "metadata": {},
-   "source": [
-    "Now we can convert our query by simply appending the .json() method to our previously stored such that json = query.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "id": "84da38bd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "json = t.json()"
+    "patient_json = patient.json()"
    ]
   },
   {
@@ -265,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "139f9c4a",
    "metadata": {},
    "outputs": [
@@ -301,13 +269,13 @@
        " 'generalPractitioner': [{'reference': 'Practitioner/smart-Practitioner-72004454'}]}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "json"
+    "patient_json"
    ]
   },
   {
@@ -317,19 +285,11 @@
    "source": [
     "We can now visualize the specific patient data stored in this FHIR resource. As a next step we'll begin the process of converting the data into a Python Pandas Dataframe and begin working with the data in Exercise 1."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "207f1106",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Exercise_0_Introduction.ipynb
+++ b/Exercise_0_Introduction.ipynb
@@ -2,34 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2c7896a",
-   "metadata": {},
-   "source": [
-    "# FHIR for Research Workshop"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1ba37c9",
-   "metadata": {},
-   "source": [
-    "## Exercise 0 - Getting Started"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "877984cd",
-   "metadata": {},
-   "source": [
-    "### Motivation / Purpose"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "e0759183",
    "metadata": {},
    "source": [
-    "\n",
+    "# FHIR for Research Workshop\n",
+    "## Exercise 0 - Getting Started\n",
     "#### Exercise Objective: Introduce you to the basic mechanisms for working with FHIR\n",
     "\n",
     "For this exercise, we will walk you through the following steps:\n",
@@ -49,25 +26,9 @@
    "id": "e1b59f60",
    "metadata": {},
    "source": [
-    "## Step 1: Establish a Connection to the FHIR Server"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "32d1a558",
-   "metadata": {},
-   "source": [
-    "First let's connect to our FHIR server for data retrieval.\n",
+    "## Step 1: Establish a Connection to the FHIR Server\n",
     "\n",
-    "We use the python requests library to submit a RESTful GET request formatted as a URL."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dae0761c",
-   "metadata": {},
-   "source": [
-    "Let's string together a basic query to get the status of our FHIR server. \n",
+    "First, Let's string together a basic query to get the status of our FHIR server.  We'll use the python requests library to submit a RESTful HTTP GET request formatted as a URL.\n",
     "\n",
     "Generally we'll want to use the following python notation for all our HTTP requests:\n",
     "\n",
@@ -87,12 +48,9 @@
    "source": [
     "# For making HTTP requests to the FHIR server\n",
     "import requests\n",
-    "# Python standard library API for dealing with json\n",
-    "import json\n",
     "\n",
     "# Configure requests session with standard headers\n",
     "s = requests.Session()\n",
-    "s.headers.update({'Accept':'application/fhir+json', 'Content-Type': 'application/fhir+json'})\n",
     "\n",
     "# Optional: Turn off SSL verification. Useful when dealing with a corporate proxy with self-signed certificates.\n",
     "s.verify = False\n",
@@ -134,14 +92,8 @@
    "id": "16b58166",
    "metadata": {},
    "source": [
-    "## Step 2: Format and submit a query to the server "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "79b4f77e",
-   "metadata": {},
-   "source": [
+    "## Step 2: Format and submit a query to the server\n",
+    "\n",
     "We are now positioned to submit specific queries to our FHIR server and retrieve data.\n",
     "\n",
     "Generally speaking the pattern for a RESTful GET query appended to a URL will take the form of: \n",
@@ -194,14 +146,8 @@
    "id": "7c350ecf",
    "metadata": {},
    "source": [
-    "## Step 3: Process response data from the FHIR server as a JSON document"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f22de8a9",
-   "metadata": {},
-   "source": [
+    "## Step 3: Process response data from the FHIR server as a JSON document\n",
+    "\n",
     "The Requests library provides a `.json` method for decoding JSON HTTP response payloads into python."
    ]
   },
@@ -220,14 +166,8 @@
    "id": "5c8ea70b",
    "metadata": {},
    "source": [
-    "## Step 4: View the resulting JSON to confirm that we successfully pulled data from our remote server"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a96d983",
-   "metadata": {},
-   "source": [
+    "## Step 4: View the resulting JSON to confirm that we successfully pulled data from our remote server\n",
+    "\n",
     "Let's now output the response data to confirm we successfully accessed the server and queried data."
    ]
   },
@@ -283,7 +223,9 @@
    "id": "cc332e18",
    "metadata": {},
    "source": [
-    "We can now visualize the specific patient data stored in this FHIR resource. As a next step we'll begin the process of converting the data into a Python Pandas Dataframe and begin working with the data in Exercise 1."
+    "We can now visualize the specific patient data stored in this FHIR resource.\n",
+    "\n",
+    "In the next exercise, we'll look deeper into these and other requests and converting data into a Python Pandas Dataframe for analysis."
    ]
   }
  ],


### PR DESCRIPTION
Some narrative updates and code cleanup for Exercise 0. This exercise is small and there's a number of changes throughout.

It might be easiest to compare the two by opening the [`main branch version`](https://github.com/mitre/fhir-exercises/blob/main/Exercise_0_Introduction.ipynb) and [`this branch version`](https://github.com/mitre/fhir-exercises/blob/exercise-0-update/Exercise_0_Introduction.ipynb) in separate windows side-by-side.

- Use the standard 📘 for providing references to documentation for further reading
- Use a `request.Session()`, as we've done in Exercise 1 & 2, to disable warnings, disable ssl verification, and put common headers.
- Remove `/status_code` from `https://api.logicahealth.org/researchonfhir/open/metadata/status_code`
- Move standard HTTP request format down closer to the search it applied to (the patient search)
  - It doesn't't actually map to the `capabilities` interaction
- Update the `.json()` narrative to indicate the method comes from `requests`
- Collapse narrative and code sections together when appropriate
- Other minor narrative updates.
