### PR TITLE
Exercise 2 cookie check

### DIFF
--- a/Exercise_2_KidsFirst.ipynb
+++ b/Exercise_2_KidsFirst.ipynb
@@ -84,6 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
     "import json\n",
     "import requests\n",
     "import pandas as pd \n",
@@ -118,6 +119,12 @@
     "s.cookies['AWSELBAuthSessionCookie-0'] = kf_cookie\n",
     "\n",
     "\n",
+    "# Test out the cookie by querying the server metadata\n",
+    "r = s.get(f\"{FHIR_SERVER}/metadata\")\n",
+    "\n",
+    "if \"<!DOCTYPE html>\" in r.text:\n",
+    "    sys.stderr.write('ERROR: Could not authenticate with Kids First. The cookie may need to be updated')\n",
+    "    \n",
     "\n",
     "# This helper method allows us to easily switch between printing an entire Bundle, or just the first 20 lines.\n",
     "# Set truncate_for_github = False for actual use,\n",
@@ -133,6 +140,14 @@
     "    else:   \n",
     "        print('\\n'.join(lines[:20]))\n",
     "        print('...\\nBundle truncated. Change the \"print_bundle\" function above to print the full content.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pleased-needle",
+   "metadata": {},
+   "source": [
+    "If you see the message \"Could not authenticate with Kids First. The cookie may need to be updated\" then let the instructors know ASAP so they can fetch a new cookie, or [see these instructions to fetch a cookie](https://github.com/kids-first/kf-api-fhir-service#authenticate-to-access-server-environment)"
    ]
   },
   {

--- a/Solutions/Exercise_2_KidsFirst-SOLUTION.ipynb
+++ b/Solutions/Exercise_2_KidsFirst-SOLUTION.ipynb
@@ -84,6 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
     "import json\n",
     "import requests\n",
     "import pandas as pd \n",
@@ -118,6 +119,12 @@
     "s.cookies['AWSELBAuthSessionCookie-0'] = kf_cookie\n",
     "\n",
     "\n",
+    "# Test out the cookie by querying the server metadata\n",
+    "r = s.get(f\"{FHIR_SERVER}/metadata\")\n",
+    "\n",
+    "if \"<!DOCTYPE html>\" in r.text:\n",
+    "    sys.stderr.write('ERROR: Could not authenticate with Kids First. The cookie may need to be updated')\n",
+    "    \n",
     "\n",
     "# This helper method allows us to easily switch between printing an entire Bundle, or just the first 20 lines.\n",
     "# Set truncate_for_github = False for actual use,\n",
@@ -133,6 +140,14 @@
     "    else:   \n",
     "        print('\\n'.join(lines[:20]))\n",
     "        print('...\\nBundle truncated. Change the \"print_bundle\" function above to print the full content.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "utility-backing",
+   "metadata": {},
+   "source": [
+    "If you see the message \"Could not authenticate with Kids First. The cookie may need to be updated\" then let the instructors know ASAP so they can fetch a new cookie, or [see these instructions to fetch a cookie](https://github.com/kids-first/kf-api-fhir-service#authenticate-to-access-server-environment)"
    ]
   },
   {


### PR DESCRIPTION
Adds a check in the intro of exercise 2 to verify the cookie works. We had a note in the narrative previously that said "if you see random json error it means bad cookie" but this makes it a lot more explicit:

stderr looks like this: 
![image](https://user-images.githubusercontent.com/13512036/154750051-65938d51-5296-4596-b99c-2494874ca685.png)