### PR TITLE
Update GH Pages Deploy Action Working Directory

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    working-directory: Exercise 4
+    working-directory: Exercise_4
 # See https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
 jobs:
   deploy:


### PR DESCRIPTION
After the initial github pages deploy script was created the Exercise 4 directory was renamed. This updates the GitHub Action so that it will resume automated deployment.

Whenever possible we should avoid manually pushing to the `gh-pages` branch to ensure that:
- it only contains the required static site assets (there's .DS_Store and other unnecessary files in there now)
- it accurately reflects what is in main

There are other options for sharing the content with reviewers not comfortable doing the build themselves locally that is preferrable:
- Build it yourself locally and send them the static site. They can just open up `index.html` locally and view it in their own browser
- If you _really_ need to put it on GH pages then edit the `on.push.branches` in `ghpages.yml` to be the working branch so that it updates as the branch is updated. This will at least maintain a consistent build process.

Currently, the markdown source content does not reflect the built/deployed site. Using the strategies above should alleviate this issue to some degree.